### PR TITLE
make it compile on Mac + fix warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*~
+BUILD/
+*/BUILD/

--- a/libtiff/CMakeLists.txt
+++ b/libtiff/CMakeLists.txt
@@ -130,6 +130,8 @@ configure_file(${PROJECT_SOURCE_DIR}/tiffDllConfig.h.in
   ${PROJECT_BINARY_DIR}/tiffDllConfig.h)
 configure_file(${PROJECT_SOURCE_DIR}/tif_config.h.in
   ${PROJECT_BINARY_DIR}/tif_config.h)
+configure_file(${PROJECT_SOURCE_DIR}/tiffconf.h.in
+  ${PROJECT_BINARY_DIR}/tiffconf.h)
 
 add_library(libtiff ${common_SRCS})
 target_link_libraries(libtiff zlib jpeg)

--- a/libtiff/CMakeLists.txt
+++ b/libtiff/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 2.8)
 
 project(libtiff)
 
+find_package( JPEG )
+
+include_directories(BEFORE ${JPEG_INCLUDE_DIR})
 include_directories(BEFORE ${PROJECT_SOURCE_DIR})
 include_directories(BEFORE ${PROJECT_BINARY_DIR})
 

--- a/libtiff/mkg3states.c
+++ b/libtiff/mkg3states.c
@@ -336,11 +336,11 @@ FillTable(TIFFFaxTabEnt *T, int Size, struct proto *P, int State)
     }
 }
 
-static  char* storage_class = "";
-static  char* const_class = "";
-static  int packoutput = 1;
-static  char* prebrace = "{";
-static  char* postbrace = "}";
+static const char* storage_class = "";
+static const char* const_class = "";
+static int packoutput = 1;
+static const char* prebrace = "{";
+static const char* postbrace = "}";
 
 void
 WriteTable(FILE* fd, const TIFFFaxTabEnt* T, int Size, const char* name)
@@ -381,7 +381,6 @@ int
 main(int argc, char* argv[])
 {
     FILE* fd;
-    char* outputfile;
     int c;
     extern int optind;
     extern char* optarg;
@@ -407,7 +406,7 @@ main(int argc, char* argv[])
     argv[0]);
       return (-1);
   }
-    outputfile = optind < argc ? argv[optind] : "g3states.h";
+    const char* outputfile = optind < argc ? argv[optind] : "g3states.h";
     fd = fopen(outputfile, "w");
     if (fd == NULL) {
   fprintf(stderr, "%s: %s: Cannot create output file.\n",

--- a/libtiff/tif_color.c
+++ b/libtiff/tif_color.c
@@ -126,37 +126,37 @@ TIFFCIELabToRGBInit(TIFFCIELabToRGB* cielab,
 		    const TIFFDisplay *display, float *refWhite)
 {
 	int i;
-	double gamma;
+	double t_gamma;
 
 	cielab->range = CIELABTORGB_TABLE_RANGE;
 
 	_TIFFmemcpy(&cielab->display, display, sizeof(TIFFDisplay));
 
 	/* Red */
-	gamma = 1.0 / cielab->display.d_gammaR ;
+	t_gamma = 1.0 / cielab->display.d_gammaR ;
 	cielab->rstep =
 		(cielab->display.d_YCR - cielab->display.d_Y0R)	/ cielab->range;
 	for(i = 0; i <= cielab->range; i++) {
 		cielab->Yr2r[i] = cielab->display.d_Vrwr
-		    * ((float)pow((double)i / cielab->range, gamma));
+		    * ((float)pow((double)i / cielab->range, t_gamma));
 	}
 
 	/* Green */
-	gamma = 1.0 / cielab->display.d_gammaG ;
+	t_gamma = 1.0 / cielab->display.d_gammaG ;
 	cielab->gstep =
 	    (cielab->display.d_YCR - cielab->display.d_Y0R) / cielab->range;
 	for(i = 0; i <= cielab->range; i++) {
 		cielab->Yg2g[i] = cielab->display.d_Vrwg
-		    * ((float)pow((double)i / cielab->range, gamma));
+		    * ((float)pow((double)i / cielab->range, t_gamma));
 	}
 
 	/* Blue */
-	gamma = 1.0 / cielab->display.d_gammaB ;
+	t_gamma = 1.0 / cielab->display.d_gammaB ;
 	cielab->bstep =
 	    (cielab->display.d_YCR - cielab->display.d_Y0R) / cielab->range;
 	for(i = 0; i <= cielab->range; i++) {
 		cielab->Yb2b[i] = cielab->display.d_Vrwb
-		    * ((float)pow((double)i / cielab->range, gamma));
+		    * ((float)pow((double)i / cielab->range, t_gamma));
 	}
 
 	/* Init reference white point */

--- a/libtiff/tif_dir.c
+++ b/libtiff/tif_dir.c
@@ -543,74 +543,74 @@ _TIFFVSetField(TIFF* tif, uint32 tag, va_list ap)
 				 * passed as a list of separate values. This behaviour
 				 * must be changed in the future!
 				 */
-				int i;
+				int ti;
 				char *val = (char *)tv->value;
 
-				for (i = 0; i < tv->count; i++, val += tv_size) {
+				for (ti = 0; ti < tv->count; ti++, val += tv_size) {
 					switch (fip->field_type) {
 						case TIFF_BYTE:
 						case TIFF_UNDEFINED:
 							{
-								uint8 v = (uint8)va_arg(ap, int);
-								_TIFFmemcpy(val, &v, tv_size);
+								uint8 t_v = (uint8)va_arg(ap, int);
+								_TIFFmemcpy(val, &t_v, tv_size);
 							}
 							break;
 						case TIFF_SBYTE:
 							{
-								int8 v = (int8)va_arg(ap, int);
-								_TIFFmemcpy(val, &v, tv_size);
+								int8 t_v = (int8)va_arg(ap, int);
+								_TIFFmemcpy(val, &t_v, tv_size);
 							}
 							break;
 						case TIFF_SHORT:
 							{
-								uint16 v = (uint16)va_arg(ap, int);
-								_TIFFmemcpy(val, &v, tv_size);
+								uint16 t_v = (uint16)va_arg(ap, int);
+								_TIFFmemcpy(val, &t_v, tv_size);
 							}
 							break;
 						case TIFF_SSHORT:
 							{
-								int16 v = (int16)va_arg(ap, int);
-								_TIFFmemcpy(val, &v, tv_size);
+								int16 t_v = (int16)va_arg(ap, int);
+								_TIFFmemcpy(val, &t_v, tv_size);
 							}
 							break;
 						case TIFF_LONG:
 						case TIFF_IFD:
 							{
-								uint32 v = va_arg(ap, uint32);
-								_TIFFmemcpy(val, &v, tv_size);
+								uint32 t_v = va_arg(ap, uint32);
+								_TIFFmemcpy(val, &t_v, tv_size);
 							}
 							break;
 						case TIFF_SLONG:
 							{
-								int32 v = va_arg(ap, int32);
-								_TIFFmemcpy(val, &v, tv_size);
+								int32 t_v = va_arg(ap, int32);
+								_TIFFmemcpy(val, &t_v, tv_size);
 							}
 							break;
 						case TIFF_LONG8:
 						case TIFF_IFD8:
 							{
-								uint64 v = va_arg(ap, uint64);
-								_TIFFmemcpy(val, &v, tv_size);
+								uint64 t_v = va_arg(ap, uint64);
+								_TIFFmemcpy(val, &t_v, tv_size);
 							}
 							break;
 						case TIFF_SLONG8:
 							{
-								int64 v = va_arg(ap, int64);
-								_TIFFmemcpy(val, &v, tv_size);
+								int64 t_v = va_arg(ap, int64);
+								_TIFFmemcpy(val, &t_v, tv_size);
 							}
 							break;
 						case TIFF_RATIONAL:
 						case TIFF_SRATIONAL:
 						case TIFF_FLOAT:
 							{
-								float v = (float)va_arg(ap, double);
-								_TIFFmemcpy(val, &v, tv_size);
+								float t_v = (float)va_arg(ap, double);
+								_TIFFmemcpy(val, &t_v, tv_size);
 							}
 							break;
 						case TIFF_DOUBLE:
 							{
-								double v = va_arg(ap, double);
-								_TIFFmemcpy(val, &v, tv_size);
+								double t_v = va_arg(ap, double);
+								_TIFFmemcpy(val, &t_v, tv_size);
 							}
 							break;
 						default:

--- a/libtiff/tif_dirread.c
+++ b/libtiff/tif_dirread.c
@@ -4475,10 +4475,10 @@ TIFFFetchDirectory(TIFF* tif, uint64 diroff, TIFFDirEntry** pdir,
 		}
 		else
 		{
-			tmsize_t m;
+			tmsize_t t_m;
 			uint64 dircount64;
-			m=off+sizeof(uint64);
-			if ((m<off)||(m<(tmsize_t)sizeof(uint64))||(m>tif->tif_size)) {
+			t_m=off+sizeof(uint64);
+			if ((t_m<off)||(t_m<(tmsize_t)sizeof(uint64))||(t_m>tif->tif_size)) {
 				TIFFErrorExt(tif->tif_clientdata, module,
 					"Can not read TIFF directory count");
 				return 0;

--- a/libtiff/tif_getimage.c
+++ b/libtiff/tif_getimage.c
@@ -1559,15 +1559,15 @@ DECLARESepPutFunc(putRGBUAseparate16bittile)
 	uint16 *wa = (uint16*) a;
 	(void) img; (void) y;
 	while (h-- > 0) {
-		uint32 r,g,b,a;
+		uint32 t_r,t_g,t_b,t_a;
 		uint8* m;
 		for (x = w; x-- > 0;) {
-			a = img->Bitdepth16To8[*wa++];
-			m = img->UaToAa+(a<<8);
-			r = m[img->Bitdepth16To8[*wr++]];
-			g = m[img->Bitdepth16To8[*wg++]];
-			b = m[img->Bitdepth16To8[*wb++]];
-			*cp++ = PACK4(r,g,b,a);
+			t_a = img->Bitdepth16To8[*wa++];
+			m = img->UaToAa+(t_a<<8);
+			t_r = m[img->Bitdepth16To8[*wr++]];
+			t_g = m[img->Bitdepth16To8[*wg++]];
+			t_b = m[img->Bitdepth16To8[*wb++]];
+			*cp++ = PACK4(t_r,t_g,t_b,t_a);
 		}
 		SKEW4(wr, wg, wb, wa, fromskew);
 		cp += toskew;

--- a/libtiff/tif_jpeg.c
+++ b/libtiff/tif_jpeg.c
@@ -688,6 +688,7 @@ static void JPEGFixupTagsSubsamplingSkip(struct JPEGFixupTagsSubsamplingData* da
 static int
 JPEGFixupTags(TIFF* tif)
 {
+  (void) tif;
 	#ifdef CHECK_JPEG_YCBCR_SUBSAMPLING
 	if ((tif->tif_dir.td_photometric==PHOTOMETRIC_YCBCR)&&
 	    (tif->tif_dir.td_planarconfig==PLANARCONFIG_CONTIG)&&

--- a/libtiff/tif_print.c
+++ b/libtiff/tif_print.c
@@ -139,6 +139,7 @@ _TIFFPrettyPrintField(TIFF* tif, FILE* fd, uint32 tag,
 		      uint32 value_count, void *raw_data)
 {
 	TIFFDirectory *td = &tif->tif_dir;
+  (void) td;
 
 	switch (tag)
 	{
@@ -526,12 +527,12 @@ TIFFPrintDirectory(TIFF* tif, FILE* fd, long flags)
 	** Custom tag support.
 	*/
 	{
-		int  i;
+		int  t_i;
 		short count;
 
 		count = (short) TIFFGetTagListCount(tif);
-		for(i = 0; i < count; i++) {
-			uint32 tag = TIFFGetTagListEntry(tif, i);
+		for(t_i = 0; t_i < count; t_i++) {
+			uint32 tag = TIFFGetTagListEntry(tif, t_i);
 			const TIFFField *fip;
 			uint32 value_count;
 			int mem_alloc = 0;

--- a/libtiff/tif_read.c
+++ b/libtiff/tif_read.c
@@ -59,7 +59,7 @@ TIFFFillStripPartial( TIFF *tif, int strip, int read_ahead, int restart )
         tmsize_t bytecountm;
         bytecountm=(tmsize_t) td->td_stripbytecount[strip];
                         
-        if (read_ahead*2 > tif->tif_rawdatasize) {
+        if ((unsigned int)read_ahead*2 > tif->tif_rawdatasize) {
                 assert( restart );
                 
                 tif->tif_curstrip = NOSTRIP;


### PR DESCRIPTION
Hi Luis,

with these changes, it compiles on Mac and I have also fixed plenty of warnings on gcc 4.4.4 (shadowed variable declarations, etc...). The remaining warnings are due to string assigment, i.e.

char\* string = "i"; it should be 
const car\* string ="i";

Arnaud
